### PR TITLE
Change collision handling

### DIFF
--- a/src/gameClasses/Drone.js
+++ b/src/gameClasses/Drone.js
@@ -2,15 +2,17 @@ var Drone = function(game, x, y) {
 
 	Phaser.Sprite.call(this, game, x, y, 'drone');
 
-	this.health = 100;
+	this.health = 3;
 	this.batteryLevel = 100;
+	this.hardCollision = 50;
+	this.velocityAtCollision = null;
 
 	// Physics
 	game.physics.enable(this);
 	this.body.allowGravity = false;
 	this.body.collideWorldBounds = true;
 	this.body.velocity.setTo(0, 0);
-	this.body.bounce.setTo(0.3, 0.3);
+	this.body.bounce.setTo(0.35, 0.35);
 	this.body.maxVelocity.set(250);
 	this.body.drag.set(150);
 
@@ -88,10 +90,24 @@ Drone.prototype.update = function() {
 
 }
 
-Drone.prototype.collide = function () {
+Drone.prototype.beforeCollision = function () {
 
-	// Reduce health by 1, update health text
-	this.health = this.health - 1;
+	// Get the player's velocity at the time of collision (player's velocity gets reset to 0 before onCollision() is called)
+	this.velocityAtCollision = this.body.velocity;
+
+	// Return true so onCollision() gets called upon collision
+	return true;
+
+}
+
+Drone.prototype.onCollision = function () {
+
+	if (Math.abs(this.velocityAtCollision.x) >= this.hardCollision || Math.abs(this.velocityAtCollision.y) >= this.hardCollision) {
+
+		// Reduce health by 1
+		this.health = this.health - 1;
+
+	}
 
 }
 

--- a/src/gameStates/Game.js
+++ b/src/gameStates/Game.js
@@ -125,11 +125,11 @@ LinkRunner.Game.prototype.update = function () {
 
 		this.batteryDrainTimer.stop();
 
-		this.stateText.text = 'GAME OVER\nClick to restart';
+		this.stateText.text = 'GAME OVER\nClick to restart level';
 		this.stateText.visible = true;
 
 		// 'click to restart' handler
-		this.game.input.onTap.addOnce(this.restart, this);
+		this.game.input.onTap.addOnce(this.reloadLevel, this);
 	}
 
 }
@@ -192,21 +192,9 @@ LinkRunner.Game.prototype.reduceBatteryPower = function () {
 
 },
 
-LinkRunner.Game.prototype.restart = function () {
+LinkRunner.Game.prototype.reloadLevel = function () {
 
-	// Revive the player
-	this.player.revive();
-	this.player.body.velocity.setTo(0, 0);
-	this.player.health = 100;
-	this.player.batteryLevel = 100;
-
-	// Recreate battery drain timer
-	this.batteryDrainTimer = this.game.time.create(false);
-	this.batteryDrainTimer.loop(5000, this.reduceBatteryPower, this);
-	this.batteryDrainTimer.start();
-
-	// Hide state text
-	this.stateText.visible = false;
+	this.game.state.start('Game');
 
 }
 

--- a/src/gameStates/Game.js
+++ b/src/gameStates/Game.js
@@ -110,11 +110,14 @@ LinkRunner.Game.prototype.create = function () {
 
 LinkRunner.Game.prototype.update = function () {
 
+	// Debugging
+	this.game.debug.bodyInfo(this.player, 20, 100);
+
 	// Update the HUD
 	this.hudUpdate();
 
 	// Check for collisions
-	this.game.physics.arcade.overlap(this.player, this.pipeWalls, this.player.collide, null, this.player);
+	this.game.physics.arcade.collide(this.player, this.pipeWalls, this.player.onCollision, this.player.beforeCollision, this.player);
 	this.game.physics.arcade.overlap(this.player.weapon.children, this.pipeWalls, this.player.weapon.hitWall, null, this.player);
 	this.game.physics.arcade.overlap(this.player, this.endZone, this.winLevel, null, this);
 


### PR DESCRIPTION
Drones now start with 3 health.

The drone onCollision method now only reduces the player's health if their x or y velocity is above a certain amount.
