### PR TITLE
Flash hud text

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -28,3 +28,8 @@ body {
 	text-align: center;
 	vertical-align: middle;
 }
+
+#hud p em {
+	color: red;
+	font-style: normal;
+}

--- a/src/gameClasses/Drone.js
+++ b/src/gameClasses/Drone.js
@@ -112,7 +112,7 @@ Drone.prototype.onCollision = function () {
 		this.health = this.health - 1;
 
 		// Dispatch event to emphasize health text
-		LinkRunner.Game.hudBlink.dispatch('health');
+		this.game.events.hudBlink.dispatch('health');
 
 	}
 

--- a/src/gameClasses/Drone.js
+++ b/src/gameClasses/Drone.js
@@ -111,6 +111,9 @@ Drone.prototype.onCollision = function () {
 		// Reduce health by 1
 		this.health = this.health - 1;
 
+		// Dispatch event to emphasize health text
+		LinkRunner.Game.hudBlink.dispatch('health');
+
 	}
 
 };

--- a/src/gameClasses/Weapon.js
+++ b/src/gameClasses/Weapon.js
@@ -40,7 +40,11 @@ Weapon.Beam.prototype.fire = function (source) {
 
 	this.getFirstExists(false).fire(x, y, this.bulletSpeed, direction);
 
+	// Reduce the battery level
 	source.batteryLevel -= source.batteryDrainWhenFiring;
+
+	// Emphasize the battery text
+	this.game.events.hudBlink.dispatch('battery');
 
 	this.nextFire = this.game.time.time + this.fireRate;
 

--- a/src/gameStates/Game.js
+++ b/src/gameStates/Game.js
@@ -73,12 +73,15 @@ LinkRunner.Game.prototype.create = function () {
 	// Show HUD
 	this.game.$hud.show();
 
-	// Initialize hudEmphasis variable
-	this.hudEmphasis = '';
+	// Initialize values for HUD emphasis
+	this.hudEmphasizeHealth = false;
+	this.hudEmphasizeBattery = false;
+	this.hudEmphasizeTime = false;
 
 	// Create event listener for HUD blinking
-	this.hudBlink = new Phaser.Signal();
-	this.hudBlink.add(this.handleHudBlink, this); // listener, listenerContext, priority, args
+	if (this.game.events == undefined) { this.game.events = {}; }
+	this.game.events.hudBlink = new Phaser.Signal();
+	this.game.events.hudBlink.add(this.handleHudBlink, this); // listener, listenerContext, priority, args
 
 	// Set the game's start time (miliseconds)
 	this.startTime = this.game.time.now;
@@ -140,23 +143,23 @@ LinkRunner.Game.prototype.hudUpdate = function () {
 	hudHTML = "<p>";
 
 	// Health
-	if ( this.hudEmphasis == 'health' ) { hudHTML += "<em>"; }
+	if (this.hudEmphasizeHealth) { hudHTML += "<em>"; }
 	hudHTML += "Health: " + this.player.health;
-	if ( this.hudEmphasis == 'health' ) { hudHTML += "</em>"; }
+	if (this.hudEmphasizeHealth) { hudHTML += "</em>"; }
 
 	hudHTML += "  |  ";
 
 	// Battery
-	if ( this.hudEmphasis == 'battery' ) { hudHTML += "<em>"; }
+	if (this.hudEmphasizeBattery) { hudHTML += "<em>"; }
 	hudHTML += "Battery: " + this.player.batteryLevel;
-	if ( this.hudEmphasis == 'battery' ) { hudHTML += "</em>"; }
+	if (this.hudEmphasizeBattery) { hudHTML += "</em>"; }
 
 	hudHTML += "  |  ";
 
 	// Time elapsed
-	if ( this.hudEmphasis == 'time' ) { hudHTML += "<em>"; }
+	if (this.hudEmphasizeTime) { hudHTML += "<em>"; }
 	hudHTML += "Time elapsed: " + minutes + ":" + ( seconds < 10 ? "0" + seconds : seconds );
-	if ( this.hudEmphasis == 'time' ) { hudHTML += "</em>"; }
+	if (this.hudEmphasizeTime) { hudHTML += "</em>"; }
 
 	hudHTML += "</p>";
 
@@ -164,16 +167,43 @@ LinkRunner.Game.prototype.hudUpdate = function () {
 	
 };
 
-LinkRunner.Game.prototype.handleHudBlink = function ( section ) {
+LinkRunner.Game.prototype.handleHudBlink = function (section) {
 
 	// Set the duration for hud text to be emphasized in
 	var hudBlinkTime = 500;
 
-	// set text to emphasize
-	this.hudEmphasis = section;
+	if (section == 'health')
+	{
+		// set text to emphasize
+		this.hudEmphasizeHealth = true;
 
-	// Remove text emphasis after the duration defined by hudBlinkTime
-	this.game.time.events.add( hudBlinkTime, function(){ this.hudEmphasis = '' }, this );
+		// Remove text emphasis after the duration defined by hudBlinkTime
+		this.game.time.events.add(hudBlinkTime, function(){ this.hudEmphasizeHealth = false; }, this );
+
+		return;
+	}
+
+	if (section == 'battery')
+	{
+		// set text to emphasize
+		this.hudEmphasizeBattery = true;
+
+		// Remove text emphasis after the duration defined by hudBlinkTime
+		this.game.time.events.add(hudBlinkTime, function(){ this.hudEmphasizeBattery = false; }, this );
+
+		return;
+	}
+
+	if (section == 'time')
+	{
+		// set text to emphasize
+		this.hudEmphasizeTime = true;
+
+		// Remove text emphasis after the duration defined by hudBlinkTime
+		this.game.time.events.add(hudBlinkTime, function(){ this.hudEmphasizeTime = false; }, this );
+
+		return;
+	}
 
 };
 

--- a/src/gameStates/Game.js
+++ b/src/gameStates/Game.js
@@ -73,6 +73,13 @@ LinkRunner.Game.prototype.create = function () {
 	// Show HUD
 	this.game.$hud.show();
 
+	// Initialize hudEmphasis variable
+	this.hudEmphasis = '';
+
+	// Create event listener for HUD blinking
+	this.hudBlink = new Phaser.Signal();
+	this.hudBlink.add(this.handleHudBlink, this); // listener, listenerContext, priority, args
+
 	// Set the game's start time (miliseconds)
 	this.startTime = this.game.time.now;
 
@@ -131,14 +138,43 @@ LinkRunner.Game.prototype.hudUpdate = function () {
 
 	var hudHTML;
 	hudHTML = "<p>";
+
+	// Health
+	if ( this.hudEmphasis == 'health' ) { hudHTML += "<em>"; }
 	hudHTML += "Health: " + this.player.health;
+	if ( this.hudEmphasis == 'health' ) { hudHTML += "</em>"; }
+
 	hudHTML += "  |  ";
+
+	// Battery
+	if ( this.hudEmphasis == 'battery' ) { hudHTML += "<em>"; }
 	hudHTML += "Battery: " + this.player.batteryLevel;
+	if ( this.hudEmphasis == 'battery' ) { hudHTML += "</em>"; }
+
 	hudHTML += "  |  ";
+
+	// Time elapsed
+	if ( this.hudEmphasis == 'time' ) { hudHTML += "<em>"; }
 	hudHTML += "Time elapsed: " + minutes + ":" + ( seconds < 10 ? "0" + seconds : seconds );
+	if ( this.hudEmphasis == 'time' ) { hudHTML += "</em>"; }
+
 	hudHTML += "</p>";
+
 	this.game.$hud.html(hudHTML);
 	
+};
+
+LinkRunner.Game.prototype.handleHudBlink = function ( section ) {
+
+	// Set the duration for hud text to be emphasized in
+	var hudBlinkTime = 500;
+
+	// set text to emphasize
+	this.hudEmphasis = section;
+
+	// Remove text emphasis after the duration defined by hudBlinkTime
+	this.game.time.events.add( hudBlinkTime, function(){ this.hudEmphasis = '' }, this );
+
 };
 
 LinkRunner.Game.prototype.winLevel = function () {


### PR DESCRIPTION
Created event handlers to 'blink' portions of the HUD text by temporarily changing their color to red.

When the drone fires a shot, the battery portion of the HUD text flashes red to emphasize the fact that laser shots drain the battery faster.

When the drone collides with a wall, the health portion of the HUD text flashes red to emphasize the reduction in health.
